### PR TITLE
Improve robustness of 1D GESPAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,5 @@ python -m py3dgespar --plot
 ```
 
 The Python code provides basic functions for experimenting with the 3D-GESPAR
-approach.
+approach. The 1D variant assumes an even signal length; providing an odd length
+will raise a ``ValueError``.

--- a/demo_gespar_3d_figs.py
+++ b/demo_gespar_3d_figs.py
@@ -7,7 +7,9 @@ def main():
     snr = np.inf
     max_t = 1000
     epoches = 30
-    dimlen = 7
+    # ``run_gespar1d`` expects an even signal length. The demo uses an even cube
+    # dimension so the flattened signal length is even as well.
+    dimlen = 6
     n = dimlen ** 3
     m = n
     ks = np.arange(2, 27, 2)

--- a/py3dgespar/gespar1d.py
+++ b/py3dgespar/gespar1d.py
@@ -123,6 +123,32 @@ def gespar_1df(c, n, k, iterations, verbose, F, ac, noisy,
 
 
 def run_gespar1d(x, F, n, k, maxT, snr, verbose=False):
+    """Run one trial of the 1D GESPAR algorithm.
+
+    Parameters
+    ----------
+    x : ndarray
+        The ground-truth sparse signal.
+    F : ndarray
+        Discrete Fourier transform matrix of size ``n``.
+    n : int
+        Length of ``F``. Must be even.
+    k : int
+        Sparsity level of ``x``.
+    maxT : int
+        Maximum number of allowed replacements.
+    snr : float
+        Measurement SNR (``np.inf`` for noiseless).
+    verbose : bool, optional
+        If ``True``, print progress information.
+
+    Notes
+    -----
+    The implementation mirrors the original MATLAB code and relies on an even
+    signal length. If ``n`` is odd a ``ValueError`` is raised.
+    """
+    if n % 2 == 1:
+        raise ValueError("n must be even for the 1D variant")
     c = np.abs(np.fft.fft(x)) ** 2
     noise_std = 0.0 if np.isinf(snr) else np.sqrt(np.mean(c) / (10 ** (snr / 10)))
     cn = c + np.random.normal(scale=noise_std, size=c.shape)


### PR DESCRIPTION
## Summary
- document even-length requirement in README
- clarify signal length restriction in the demo script
- add docstring and explicit even-length check to `run_gespar1d`

## Testing
- `python -m py3dgespar --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68695699f8c88331ab794507b3b89ea4